### PR TITLE
Use SameSite Lax for dev cookie

### DIFF
--- a/internal/dev/dev.go
+++ b/internal/dev/dev.go
@@ -72,7 +72,7 @@ func Middleware(bcryptHash string, sessionDuration time.Duration, jwtEc256 *ecds
 						Expires:  exp,
 						Secure:   !(r.URL.Host == "localhost" || devDisableSecure),
 						HttpOnly: true,
-						SameSite: http.SameSiteStrictMode,
+						SameSite: http.SameSiteLaxMode,
 					}
 					http.SetCookie(w, c)
 					log.New().WithField("dev_email", email).WithField("dev", "success, set cookie").AddToContext(r.Context())


### PR DESCRIPTION
When using SameSite Strict the browser will prevent the cookie from being included when clicking links to that domain. So for example clicking a link to flat2 during a dump will not work with this setting enabled.