### PR TITLE
Rename 'latency' log-field, to 'latency_human'

### DIFF
--- a/internal/log/middleware.go
+++ b/internal/log/middleware.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"github.com/google/uuid"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type contextKey struct{}
@@ -26,7 +27,7 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 		New().
 			WithField("path", r.URL.Path).
-			WithField("latency", time.Now().Sub(t).Round(time.Millisecond).String()).
+			WithField("latency_human", time.Since(t).String()).
 			WithField("status", w.status).
 			WithField("encoding", w.Header().Get("Content-Encoding")).
 			WithField("request_id", requestId).


### PR DESCRIPTION
Rename the 'latency' log-field, to 'latency_human' to match the twofer log field. Twofer log both 'latency' and 'latency_human' log-fields, but the 'laency' field is numerical in the Twofer log-output, but is a string in epoxy log-output, causing issues in ELK.