### PR TITLE
Bump GO version and add -slim image

### DIFF
--- a/build-push.sh
+++ b/build-push.sh
@@ -6,11 +6,22 @@ IMAGE_NAME=modfin/${NAME}
 
 BUILDER=$(docker buildx create) || exit 1
 
-docker buildx build --builder=${BUILDER} --push \
+docker buildx build --builder=${BUILDER} \
+    --push \
+    --target epoxy \
     --platform linux/amd64,linux/arm64 \
     -f ./Dockerfile \
     -t ${IMAGE_NAME}:latest \
     -t ${IMAGE_NAME}:${VERSION} \
+    .
+
+docker buildx build --builder=${BUILDER} \
+    --push \
+    --target epoxy-slim \
+    --platform linux/amd64,linux/arm64 \
+    -f ./Dockerfile \
+    -t ${IMAGE_NAME}-slim:latest \
+    -t ${IMAGE_NAME}-slim:${VERSION} \
     .
 
 docker buildx rm "${BUILDER}"


### PR DESCRIPTION
Update GO version to fix known CVE's and refactor image build and add a -slim image that is based on the scratch image.